### PR TITLE
Supporting map initialization event handling on server-side

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ In order to use Google Maps API, you'll need to get an API key from [Google Deve
 
 * Map move
 * Map click
+* Map initialized
 * Marker drag
 * Marker click
 * Info window close

--- a/googlemaps-demo/src/main/java/com/vaadin/tapio/googlemaps/demo/DemoUI.java
+++ b/googlemaps-demo/src/main/java/com/vaadin/tapio/googlemaps/demo/DemoUI.java
@@ -20,6 +20,7 @@ import com.vaadin.tapio.googlemaps.client.overlays.GoogleMapMarker;
 import com.vaadin.tapio.googlemaps.client.overlays.GoogleMapPolygon;
 import com.vaadin.tapio.googlemaps.client.overlays.GoogleMapPolyline;
 import com.vaadin.tapio.googlemaps.demo.events.OpenInfoWindowOnMarkerClickListener;
+import com.vaadin.tapio.googlemaps.events.MapInitializedListener;
 import com.vaadin.ui.*;
 import com.vaadin.ui.Button.ClickEvent;
 
@@ -98,6 +99,22 @@ public class DemoUI extends UI {
         HorizontalLayout buttonLayoutRow2 = new HorizontalLayout();
         buttonLayoutRow2.setHeight("26px");
         mapContent.addComponent(buttonLayoutRow2);
+
+        googleMap.addMapInitializedListener(new MapInitializedListener() {
+            @Override
+            public void mapInitialized(GoogleMap source) {
+                // At this point the map has been drawn.
+                // So for example you can set initial viewport by uncommenting the line below.
+
+                // fitToBounds only works when the map has size (has been drawn)
+                // https://developers.google.com/maps/documentation/javascript/reference/map#Map.fitBounds
+
+                //source.fitToBounds(maariaMarker.getPosition(), kakolaMarker.getPosition())
+
+                Label consoleEntry = new Label("Map has been initialized.");
+                consoleLayout.addComponent(consoleEntry, 0);
+            }
+        });
 
         OpenInfoWindowOnMarkerClickListener infoWindowOpener = new OpenInfoWindowOnMarkerClickListener(
             googleMap, kakolaMarker, kakolaInfoWindow);

--- a/googlemaps/src/main/java/com/vaadin/tapio/googlemaps/GoogleMap.java
+++ b/googlemaps/src/main/java/com/vaadin/tapio/googlemaps/GoogleMap.java
@@ -26,10 +26,12 @@ import com.vaadin.tapio.googlemaps.client.overlays.GoogleMapPolyline;
 import com.vaadin.tapio.googlemaps.client.overlays.GoogleMapCircle;
 import com.vaadin.tapio.googlemaps.client.rpcs.InfoWindowClosedRpc;
 import com.vaadin.tapio.googlemaps.client.rpcs.MapClickedRpc;
+import com.vaadin.tapio.googlemaps.client.rpcs.MapInitializedRpc;
 import com.vaadin.tapio.googlemaps.client.rpcs.MapMovedRpc;
 import com.vaadin.tapio.googlemaps.client.rpcs.MapTypeChangedRpc;
 import com.vaadin.tapio.googlemaps.client.rpcs.MarkerClickedRpc;
 import com.vaadin.tapio.googlemaps.client.rpcs.MarkerDraggedRpc;
+import com.vaadin.tapio.googlemaps.events.MapInitializedListener;
 import com.vaadin.ui.AbstractComponentContainer;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.CssLayout;
@@ -93,6 +95,15 @@ public class GoogleMap extends AbstractComponentContainer {
         }
     };
 
+    private final MapInitializedRpc mapInitializedRpc = new MapInitializedRpc() {
+        @Override
+        public void mapInitialized() {
+            for (MapInitializedListener mapInitializedListener : mapInitializedListeners) {
+                mapInitializedListener.mapInitialized(GoogleMap.this);
+            }
+        }
+    };
+
     private final InfoWindowClosedRpc infoWindowClosedRpc = new InfoWindowClosedRpc() {
 
         @Override
@@ -119,6 +130,8 @@ public class GoogleMap extends AbstractComponentContainer {
     private final List<MapMoveListener> mapMoveListeners = new ArrayList<>();
 
     private final List<MapClickListener> mapClickListeners = new ArrayList<>();
+
+    private final List<MapInitializedListener> mapInitializedListeners = new ArrayList<>();
 
     private final List<MarkerDragListener> markerDragListeners = new ArrayList<>();
 
@@ -165,6 +178,7 @@ public class GoogleMap extends AbstractComponentContainer {
         registerRpc(markerClickedRpc);
         registerRpc(mapMovedRpc);
         registerRpc(mapClickedRpc);
+        registerRpc(mapInitializedRpc);
         registerRpc(markerDraggedRpc);
         registerRpc(infoWindowClosedRpc);
         registerRpc(mapTypeChangedRpc);
@@ -347,6 +361,24 @@ public class GoogleMap extends AbstractComponentContainer {
      */
     public void removeMapClickListener(MapClickListener listener) {
         mapClickListeners.remove(listener);
+    }
+
+    /**
+     * Adds a MapInitializedListener to the map.
+     *
+     * @param listener The listener to add.
+     */
+    public void addMapInitializedListener(MapInitializedListener listener) {
+        mapInitializedListeners.add(listener);
+    }
+
+    /**
+     * Removes a MapInitializedListener from the map.
+     *
+     * @param listener The listener to remove.
+     */
+    public void removeMapInitializedListener(MapInitializedListener listener) {
+        mapInitializedListeners.remove(listener);
     }
 
     /**

--- a/googlemaps/src/main/java/com/vaadin/tapio/googlemaps/client/GoogleMapConnector.java
+++ b/googlemaps/src/main/java/com/vaadin/tapio/googlemaps/client/GoogleMapConnector.java
@@ -32,6 +32,7 @@ import com.vaadin.tapio.googlemaps.client.overlays.GoogleMapInfoWindow;
 import com.vaadin.tapio.googlemaps.client.overlays.GoogleMapMarker;
 import com.vaadin.tapio.googlemaps.client.rpcs.InfoWindowClosedRpc;
 import com.vaadin.tapio.googlemaps.client.rpcs.MapClickedRpc;
+import com.vaadin.tapio.googlemaps.client.rpcs.MapInitializedRpc;
 import com.vaadin.tapio.googlemaps.client.rpcs.MapMovedRpc;
 import com.vaadin.tapio.googlemaps.client.rpcs.MapTypeChangedRpc;
 import com.vaadin.tapio.googlemaps.client.rpcs.MarkerClickedRpc;
@@ -56,6 +57,8 @@ public class GoogleMapConnector extends AbstractComponentContainerConnector
         this);
     private final MapClickedRpc mapClickRpc = RpcProxy
         .create(MapClickedRpc.class, this);
+    private final MapInitializedRpc mapInitializedRpc = RpcProxy
+        .create(MapInitializedRpc.class, this);
     private final MarkerDraggedRpc markerDraggedRpc = RpcProxy
         .create(MarkerDraggedRpc.class, this);
     private final InfoWindowClosedRpc infoWindowClosedRpc = RpcProxy
@@ -124,6 +127,7 @@ public class GoogleMapConnector extends AbstractComponentContainerConnector
         for (GoogleMapInitListener listener : initListeners) {
             listener.mapWidgetInitiated(map);
         }
+        mapInitializedRpc.mapInitialized();
     }
 
     @Override

--- a/googlemaps/src/main/java/com/vaadin/tapio/googlemaps/client/rpcs/MapInitializedRpc.java
+++ b/googlemaps/src/main/java/com/vaadin/tapio/googlemaps/client/rpcs/MapInitializedRpc.java
@@ -1,0 +1,10 @@
+package com.vaadin.tapio.googlemaps.client.rpcs;
+
+import com.vaadin.shared.communication.ServerRpc;
+
+/**
+ * An RPC from client to server that is called when the map has been initialized.
+ */
+public interface MapInitializedRpc extends ServerRpc {
+    void mapInitialized();
+}

--- a/googlemaps/src/main/java/com/vaadin/tapio/googlemaps/events/MapInitializedListener.java
+++ b/googlemaps/src/main/java/com/vaadin/tapio/googlemaps/events/MapInitializedListener.java
@@ -1,0 +1,15 @@
+package com.vaadin.tapio.googlemaps.events;
+
+import com.vaadin.tapio.googlemaps.GoogleMap;
+
+import java.io.Serializable;
+
+/**
+ * Interface for listening map initialization event.
+ */
+public interface MapInitializedListener extends Serializable {
+    /**
+     * Handle a MapInitializedListener.
+     */
+    void mapInitialized(GoogleMap source);
+}


### PR DESCRIPTION
Hey!

I use this Vaadin Addon in my current Vaadin 8 based project and there is a need to set the map's initial viewport to fit all markers added. Unfortunately I can't use `setCenter` and `setZoom`. It would be inconvenient, because I had to calculate the center and zoom by marker positions. There is already a `fitToBounds` method for this purpose but according to the official [Google Maps Javascript API reference](https://developers.google.com/maps/documentation/javascript/reference/map#Map.fitBounds), it is only works when the map element in the DOM has size. So after when it has been rendered by GWT.

So I called this method during initialization of my vaadin view, but it doesn't worked.
This is why I added support for map initialization event. After this event, in the handler, I can call `fitToBounds` and it is working at this point.

